### PR TITLE
Replace section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
     "require": {
         "contao-community-alliance/composer-plugin": "~2.0"
     },
+    "replace": {
+        "contao-legacy/official_demo": "self.version"
+    },
     "extra": {
         "contao": {
             "sources": {


### PR DESCRIPTION
I've added the replace section for composer installations of this demo.
The Contao composer plugin is not able to resolve the old ER name ```official_demo``` to ```official-demo```.