### PR TITLE
Replace extension manager with Contao Manager in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ Contao Official Demo
 ====================
 
 This is an example website for Contao Open Source CMS. It can be installed with
-the extension manager in the Contao back end. Visit the [project website][1] for
-more information.
+the Contao Manager. Visit the [project website][1] for more information.
 
 
 [1]: https://contao.org


### PR DESCRIPTION
Considering Contao 3.5 is outdated, replace extension manager with Contao Manager in README.md.